### PR TITLE
Fix type error

### DIFF
--- a/src/PhitFlyerClient.php
+++ b/src/PhitFlyerClient.php
@@ -267,7 +267,7 @@ class PhitFlyerClient implements PhitFlyerClientInterface
             }
             return $json;
         }
-        catch(Throwable $e)
+        catch(Exception $e)
         {
             throw new PhitFlyerClientException('NetDriver#sendRequest() failed: ' . $e->getMessage(), $e);
         }


### PR DESCRIPTION
Type error issue:

`PhitFlyerClientException::__construct(string $message, Exception $prev = null)` , but it defines throwable.
It can't work on PHP 7.2