### PR TITLE
Requirement does't follow enough PHP libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ $markets = $client->getMarkets();
 ## Requirement
 
 PHP 5.5 or later
-
+php-mbstring
+php-xml
 
 ## Installing phitFlyer
 


### PR DESCRIPTION
`php-mbstring` and `php-xml` are very popular, but basically they are not bundled normally.
English speakers don't care php-mbstring.